### PR TITLE
Harden HF captioning: retries/backoff, timeout, REST fallback; env knobs; clearer AI error surfacing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ S3_BUCKET_NAME=textile-inventory-images
 
 # AI Service Configuration
 HUGGINGFACE_API_KEY=your-huggingface-api-key
+# Optional: Hugging Face request tuning
+HF_TIMEOUT_MS=20000
+HF_MAX_RETRIES=2
+HF_BACKOFF_MS=500

--- a/routes/images.js
+++ b/routes/images.js
@@ -77,6 +77,7 @@ router.post('/upload/:productId', upload.single('image'), async (req, res) => {
         }
       } catch (error) {
         console.error('AI generation failed:', error);
+        imageData.aiError = (error && error.message) ? error.message : 'AI generation failed';
         // Continue without AI data - user can retry later
       }
     }
@@ -97,7 +98,8 @@ router.post('/upload/:productId', upload.single('image'), async (req, res) => {
       data: {
         imageId: imageId,
         url: req.file.location,
-        aiGenerated: imageData.aiGenerated || null
+        aiGenerated: imageData.aiGenerated || null,
+        aiError: imageData.aiError || null
       }
     });
     


### PR DESCRIPTION
# Harden HF captioning: retries/backoff, timeout, REST fallback; env knobs; clearer AI error surfacing

## Summary

Addresses GitHub Issue #1 by implementing robust error handling and fallback mechanisms for Hugging Face API connectivity issues. The changes add configurable timeouts, exponential backoff retries, and a REST API fallback when the HfInference SDK fails, while maintaining the existing LLM-only policy (no synthetic fallbacks).

**Key Changes:**
- Added retry logic with exponential backoff for transient HF API failures
- Implemented direct REST API fallback using axios when SDK calls fail
- Made timeout/retry parameters configurable via environment variables
- Enhanced error reporting with clearer HF-specific error messages
- Maintained existing behavior: no AI generation still allows product uploads to proceed

## Review & Testing Checklist for Human

**🔴 HIGH PRIORITY** - This PR modifies critical AI generation logic and hasn't been tested with live HF API:

- [ ] **Test with valid HUGGINGFACE_API_KEY** - Upload an image with "Generate AI" enabled and verify the retry/fallback logic works end-to-end
- [ ] **Test error scenarios** - Try with invalid/expired HF token, network timeouts, and rate limiting to ensure graceful degradation  
- [ ] **Verify timeout values** - Check that default 20s timeout + 2 retries is appropriate for your use case (may need tuning)
- [ ] **Test upload flow resilience** - Ensure product uploads still succeed when AI generation fails completely
- [ ] **Check error message clarity** - Verify AI errors are helpful to users without exposing sensitive API details

**Recommended Test Plan:**
1. Set up valid `HUGGINGFACE_API_KEY` in local environment
2. Upload images across different product types (bed-covers, sarees, etc.)
3. Temporarily break connectivity (invalid token, wrong endpoint) to test fallback paths
4. Monitor logs for proper retry attempts and final error handling

## Review & Testing Checklist for Human

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Client["Client Upload<br/>POST /api/images/upload"] --> Routes["routes/images.js"]:::minor-edit
    Routes --> AiService["services/aiService.js<br/>generateProductDescription()"]:::major-edit
    
    AiService --> InstructBLIP["InstructBLIP<br/>generateInstructBLIPCaption()"]
    InstructBLIP --> HfSDK["HfInference SDK<br/>imageToText()"]
    HfSDK --> |"retry with backoff"| HfSDK
    HfSDK --> |"if SDK fails"| RestFallback["REST API Fallback<br/>hfRestImageToText()"]
    RestFallback --> |"retry with backoff"| RestFallback
    
    RestFallback --> HfAPI["api-inference.huggingface.co"]
    HfSDK --> HfAPI
    
    EnvExample[".env.example<br/>HF_TIMEOUT_MS<br/>HF_MAX_RETRIES"]:::minor-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **LLM-Only Policy Maintained**: No synthetic/heuristic fallbacks are generated when HF API is unavailable
- **Backward Compatibility**: Existing upload flow continues to work; AI generation is optional and gracefully degrades
- **Configuration**: New environment variables have sensible defaults but can be tuned for production needs
- **Error Isolation**: HF API failures don't break the core product upload functionality

**Link to Devin run**: https://app.devin.ai/sessions/11f5f3bd929045f498224fdd48da51ef  
**Requested by**: @parthobardhan